### PR TITLE
build: make: use jemalloc by default and allow opt-in to scudo (1/3)

### DIFF
--- a/core/config_sanitizers.mk
+++ b/core/config_sanitizers.mk
@@ -266,7 +266,7 @@ ifneq ($(filter address thread hwaddress,$(my_sanitize)),)
 endif
 
 # Or if disabled globally.
-ifeq ($(PRODUCT_DISABLE_SCUDO),true)
+ifneq ($(PRODUCT_USE_SCUDO),true)
   my_sanitize := $(filter-out scudo,$(my_sanitize))
 endif
 

--- a/core/product.mk
+++ b/core/product.mk
@@ -241,8 +241,8 @@ _product_list_vars += PRODUCT_CFI_INCLUDE_PATHS
 # Whether any paths are excluded from sanitization when SANITIZE_TARGET=cfi
 _product_list_vars += PRODUCT_CFI_EXCLUDE_PATHS
 
-# Whether the Scudo hardened allocator is disabled platform-wide
-_product_single_value_vars += PRODUCT_DISABLE_SCUDO
+# Whether the Scudo hardened allocator is enabled platform-wide
+_product_single_value_vars += PRODUCT_USE_SCUDO
 
 # List of extra VNDK versions to be included
 _product_list_vars += PRODUCT_EXTRA_VNDK_VERSIONS

--- a/core/soong_config.mk
+++ b/core/soong_config.mk
@@ -111,8 +111,6 @@ $(call add_json_list, MemtagHeapExcludePaths,            $(MEMTAG_HEAP_EXCLUDE_P
 $(call add_json_list, MemtagHeapAsyncIncludePaths,       $(MEMTAG_HEAP_ASYNC_INCLUDE_PATHS) $(PRODUCT_MEMTAG_HEAP_ASYNC_INCLUDE_PATHS))
 $(call add_json_list, MemtagHeapSyncIncludePaths,        $(MEMTAG_HEAP_SYNC_INCLUDE_PATHS) $(PRODUCT_MEMTAG_HEAP_SYNC_INCLUDE_PATHS))
 
-$(call add_json_bool, DisableScudo,                      $(filter true,$(PRODUCT_DISABLE_SCUDO)))
-
 $(call add_json_bool, ClangTidy,                         $(filter 1 true,$(WITH_TIDY)))
 $(call add_json_str,  TidyChecks,                        $(WITH_TIDY_CHECKS))
 
@@ -139,6 +137,7 @@ $(call add_json_list, ExtraVndkVersions,                 $(PRODUCT_EXTRA_VNDK_VE
 $(call add_json_list, DeviceSystemSdkVersions,           $(BOARD_SYSTEMSDK_VERSIONS))
 $(call add_json_str,  RecoverySnapshotVersion,           $(RECOVERY_SNAPSHOT_VERSION))
 $(call add_json_list, Platform_systemsdk_versions,       $(PLATFORM_SYSTEMSDK_VERSIONS))
+$(call add_json_bool, Malloc_use_scudo,                  $(filter true,$(PRODUCT_USE_SCUDO)))
 $(call add_json_bool, Malloc_not_svelte,                 $(call invert_bool,$(filter true,$(MALLOC_SVELTE))))
 $(call add_json_bool, Malloc_not_svelte_libc32,          $(if $(MALLOC_SVELTE_FOR_LIBC32),\
                                                             $(call invert_bool,$(filter true,$(MALLOC_SVELTE_FOR_LIBC32))),\

--- a/target/product/go_defaults_common.mk
+++ b/target/product/go_defaults_common.mk
@@ -41,11 +41,6 @@ PRODUCT_ART_TARGET_INCLUDE_DEBUG_BUILD := false
 # leave less information available via JDWP.
 PRODUCT_MINIMIZE_JAVA_DEBUG_INFO := true
 
-# Disable Scudo outside of eng builds to save RAM.
-ifneq (,$(filter eng, $(TARGET_BUILD_VARIANT)))
-  PRODUCT_DISABLE_SCUDO := true
-endif
-
 # Add the system properties.
 TARGET_SYSTEM_PROP += \
     build/make/target/board/go_defaults_common.prop


### PR DESCRIPTION
Set "PRODUCT_USE_SCUDO := true" to device.mk to use scudo in case of a jemalloc compatibility issue.

Also, clean up broken DisableScudo/PRODUCT_DISABLE_SCUDO.

Detailed reason for switching to jemalloc by default is written in the bionic commit.

Change-Id: I0983c48c1d11afb7820aad66c2838e5e3e13e6e8